### PR TITLE
fix reflector issue in nestjs v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-mqtt",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "A MQTT module for Nest.js",
   "author": "microud",
   "license": "MIT",
@@ -32,28 +32,32 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@nestjs/common": "^6.0.0",
-    "@nestjs/core": "^6.0.0",
-    "mqtt": "^3.0.0",
-    "reflect-metadata": "^0.1.12",
-    "rimraf": "^2.6.2",
-    "rxjs": "^6.3.3"
+    "mqtt": "4.3.1"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^6.10.11 || ^7.0.0 || ^8.0.0",
+    "@nestjs/core": "^6.10.11 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
-    "@nestjs/testing": "6.1.1",
+    "@nestjs/common": "^8.0.0",
+    "@nestjs/core": "^8.0.0",
+    "@nestjs/testing": "8.0.0",
     "@types/jest": "24.0.11",
     "@types/mqtt": "^2.5.0",
     "@types/node": "11.13.4",
     "@types/supertest": "2.0.7",
     "jest": "24.7.1",
     "prettier": "1.17.0",
+    "reflect-metadata": "^0.1.12",
+    "rimraf": "^2.6.2",
+    "rxjs": "^6.3.3",
     "supertest": "4.0.2",
     "ts-jest": "24.0.2",
     "ts-node": "8.1.0",
     "tsc-watch": "2.2.1",
     "tsconfig-paths": "3.8.0",
     "tslint": "5.16.0",
-    "typescript": "^3.8.3"
+    "typescript": "^4.5.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/mqtt.explorer.ts
+++ b/src/mqtt.explorer.ts
@@ -18,13 +18,13 @@ import {
 
 @Injectable()
 export class MqttExplorer implements OnModuleInit {
+  private readonly reflector = new Reflector();
   subscribers: MqttSubscriber[];
 
   constructor(
     private readonly discoveryService: DiscoveryService,
     private readonly metadataScanner: MetadataScanner,
     @Inject(MQTT_LOGGER_PROVIDER) private readonly logger: Logger,
-    private readonly reflector: Reflector,
     @Inject(MQTT_CLIENT_INSTANCE) private readonly client: Client,
     @Inject(MQTT_OPTION_PROVIDER) private readonly options: MqttModuleOptions,
   ) {

--- a/src/mqtt.module.ts
+++ b/src/mqtt.module.ts
@@ -13,7 +13,6 @@ import {
   MqttModuleOptions,
 } from './mqtt.interface';
 import {
-  MQTT_LOGGER_PROVIDER,
   MQTT_OPTION_PROVIDER,
 } from './mqtt.constants';
 
@@ -34,7 +33,6 @@ export class MqttModule {
         MqttExplorer,
         MqttService,
       ],
-      exports: [],
     };
   }
 
@@ -51,7 +49,6 @@ export class MqttModule {
         MqttExplorer,
         MqttService,
       ],
-      exports: [],
     };
   }
 }


### PR DESCRIPTION
fix injection of `Reflector` not working on NestJS v8 anymore and update dependences to [peer dependence](https://github.com/nestjs/nest/issues/7568#issuecomment-880445966).